### PR TITLE
Fix the regexp used by 30-after-load.el's custom-save-all advice

### DIFF
--- a/example/init.d/30-after-load.el
+++ b/example/init.d/30-after-load.el
@@ -44,7 +44,7 @@ on initsplit!"
          (initsplit-dynamic-customizations-alist
           (mapcar (lambda (f) 
                     `(,(progn (string-match elhome-settings-file-regexp f)
-                              (match-string 1 f))
+                              (concat "^" (match-string 1 f)))
                       ,(concat elhome-settings-directory f) nil nil))
                   sorted-files)))
 


### PR DESCRIPTION
Fix the regexp used by 30-after-load.el's custom-save-all advice
the match must be at the beginning of the variable-name. This
prevents, for example, variables such as
org-remember-store-without-prompt
from in incorrectly migrating from org-settings.el to
remember-settings.el
