### PR TITLE
Revised documentation

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -11,6 +11,25 @@ ring such that ‘C-y’ will insert it) and then ‘M-: C-y RET’
        "https://github.com/dabrahams/elhome/raw/master/elhome-install.el"
        (lambda (s) (end-of-buffer) (eval-print-last-sexp)))
 
+This will use el-get to install elhome.  Then, add code to your `.emacs` to do one of two things:
+
+* Load elhome.el manually from your init.el, and then call `(elhome-init)`. Code
+  might look like this:
+
+    (load "~/.emacs.d/el-get/elhome/elhome.el")
+    (elhome-init)
+
+* Use `el-get` to initialize elhome.  A call to `el-get` might look like this:
+
+    (setq el-get-sources
+          '(
+            (:name elhome :after elhome-init)
+           ))
+    (el-get)
+
+  If you're already using el-get to manage your packages, this is probably
+  easiest.
+
 ## Congratulations, ELHOME is now installed!
 
 There are several new directories you'll want to work with.  See the
@@ -20,8 +39,57 @@ README files in each one for more details:
 * `~/.emacs.d/elhome/startup/` - elisp that is unconditionally loaded as
   early in startup as possible.
 * `~/.emacs.d/elhome/settings/` - settings for specific modes, including
-  the general customization file settings.el
-* `~/.emacs.d/elhome/site-lisp/` - elisp files placed here (or in subdirectories) will be 
+  the general customization file settings.el (which is used as custom-file).
+* `~/.emacs.d/elhome/site-lisp/` - placed on load-path, along with any
+  subdirectories that contain emacs-lisp files.
+
+## Startup
+
+This is the first order of business for elhome.  Files are loaded in
+alphabetical order.  Look at `elhome/startup` for an example.
+
+## Settings
+
+N.B. This feature requires `after-load-functions`, introduced in Emacs 23.2.
+
+Any time a file named `foo.el` is loaded, a file in settings called
+`foo-settings.el` is loaded if it exists.
+
+Be careful with putting stuff in `lisp-mode-settings.el`, since
+`el-get` and `byte-code-cache` manipulate `.el` files, and will
+trigger these customizations right away, perhaps before they are
+ready.
+
+FIXME: need to disable lisp mode when operating on .el files.
+
+## Site-lisp
+
+This directory is put on your load path, to facilitate loading
+personal code.  Additionally, all subdirectories of `site-lisp` are
+explored, and those that contain `.el` files are also put on your load
+path, so you can organize however you like, track your own git
+submodules, etc. here without having to mess around manually with load
+paths.
+
+## Me-minor-mode
+
+Major modes often inconveniently shadow your keyboard
+customizations.  One way to get around this is to create a minor mode
+solely to contain key bindings.  elhome automatically configures a
+minor mode like this called me-minor-mode, which is globally
+activated.  So instead of code like
+
+    (define-key global-map (kbd "M-<up>") 'scroll-down-one)
+
+or
+
+    (global-define-key (kbd "M-<up>") 'scroll-down-one)
+
+You can use instead
+
+    (define-key me-minor-mode-map (kbd "M-<up>") 'scroll-down-one)
+
+## You can help
 
 Suggestions for more documentation, and especially patches, would be
 most welcome here!

--- a/elhome.el
+++ b/elhome.el
@@ -7,10 +7,9 @@
 
 
 ;; Install:
-;; You can use this file as your .emacs (or .emacs.d/init.el)
-;; directly, or symlink to it. If you need to customize where things
-;; are stored (see elhome-directory below for example) you can load it
-;; from your .emacs after setting up some constants.
+;; See README.markdown for details. You need to call (elhome-init),
+;; which el-get can do for you, or you can load this file manually and
+;; then call (elhome-init).
 
 ;; *** IMPORTANT NOTE ***: I would rather call this module ElHombre,
 ;; but can't find a good excuse.


### PR DESCRIPTION
This includes feedback from the most recent round of comments on this commit.

Notable changes:
- It is not, in fact, possible to use elhome.el as your .emacs, since
  this would not call elhome-init.  Somehow, you need to call this
  function explicitly.
- Add some text explaining me-major-mode, so that you don't have to
  crawl through source to figure out where it came from.
