### PR TITLE
Don't invoke el-get if el-get invoked us

### DIFF
--- a/startup/10-el-get.el
+++ b/startup/10-el-get.el
@@ -9,4 +9,32 @@
     (eval-print-last-sexp))
   )
 
-(el-get)
+(defun elhome-el-get-is-running ()
+  "Check to see if el-get is already running.
+
+If el-get invoked elhome, and then elhome invokes el-get, we get
+a bad recursion.
+
+On the other hand, some people prefer to have elhome manage
+el-get. In this case, el-get won't show up in the call stack, so
+we can invoke it ourselves."
+  (let ((n 0)
+        (found nil))
+    (while (and (not found) (backtrace-frame n))
+      (let* ((frame (backtrace-frame n))
+             (function (cadr frame)))
+        (let ((function-name (cond
+                              ((stringp function) function)
+                              ((symbolp function) (symbol-name function))
+                              ((listp function) "")  ; lambda
+                              ((eq (type-of function) 'compiled-function) "")
+                              (t (progn
+                                   (message "unknown form of backtrace frame %s"
+                                            frame)
+                                   "")))))
+          (setq found (string-match "^el-get" function-name))))
+      (setq n (+ 1 n)))
+  found))
+
+(when (not (elhome-el-get-is-running))
+    (el-get))


### PR DESCRIPTION
This commit implements solution number 4 on issue #16. Emacs's backtrace-inspection features aren't the most pleasant to work with, but this code worked on both my normal .emacs.d setup (where el-get invokes elhome) and an empty one that I set up according to the docs (install elhome using elhome-install, and then put `(load "el-get/elhome/elhome.el") (elhome-init)` in `init.el`).

How do you feel about this?
